### PR TITLE
Request to update LATEST BY to LATEST ON

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -158,7 +158,7 @@ when starting services:
 - [GROUP BY](/docs/reference/sql/group-by/)
 - [INSERT](/docs/reference/sql/insert/)
 - [JOIN](/docs/reference/sql/join/)
-- [LATEST BY](/docs/reference/sql/latest-on/)
+- [LATEST ON](/docs/reference/sql/latest-on/)
 - [LIMIT](/docs/reference/sql/limit/)
 - [ORDER BY](/docs/reference/sql/order-by/)
 - [RENAME TABLE](/docs/reference/sql/rename/)


### PR DESCRIPTION
In the Introduction page (https://questdb.io/docs/introduction/), 'LATEST BY' links to 'LATEST ON' command information. Also, I read that 'LATEST BY' is deprecated. So, I updated the link text. Pls accept if you agree with this action.