### PR TITLE
Request for updating a section

### DIFF
--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -208,7 +208,7 @@ working on replication, further JIT-compiled filter performance improvements,
 and more.
 
 We hope you enjoyed the features and functionality in version 6.2. See the
-[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2.0)
+[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2)
 for the complete list of additions and fixes. We’re eagerly awaiting your
 feedback, so feel free to reach out and let us know how it's running. You can
 let us know how we're doing or just come by and say hello

--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -97,18 +97,18 @@ For more information on the JIT compiler, refer to this
 
 ## New LATEST BY syntax and improvements
 
-The database now supports a new syntax for LATEST BY clause:
+The LATEST BY syntax is deprecated, and the database now supports a new syntax called LATEST ON:
 
 ```sql
 SELECT * FROM tab WHERE x > 0
 LATEST ON timestamp PARTITION BY y;
 ```
 
-This syntax makes the LATEST BY clause consistent with the query execution order
-since LATEST BY now must follow the WHERE clause. Release 6.2 also includes a
-number of fixes to make sure that the WHERE always gets applied before the
-LATEST BY. For more details on the new syntax, see the
-[LATEST BY documentation](/docs/reference/sql/latest-on/).
+This syntax makes the LATEST ON clause consistent with the query execution order
+since LATEST ON now must follow the WHERE clause. Release 6.2 also includes a
+number of fixes to make sure that the WHERE clause always gets applied before the
+LATEST ON. For more details on the new syntax, see the
+[LATEST ON documentation](/docs/reference/sql/latest-on/).
 
 ## Optimize LIMIT SQL queries
 

--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -105,8 +105,8 @@ LATEST ON timestamp PARTITION BY y;
 ```
 
 This syntax makes the LATEST ON clause consistent with the query execution order
-since LATEST ON now must follow the WHERE clause. Release 6.2 also includes a
-number of fixes to make sure that the WHERE clause always gets applied before the
+since LATEST ON follows the WHERE clause. Release 6.2 also includes a
+number of fixes to ensure that the WHERE clause always gets applied before
 LATEST ON. For more details on the new syntax, see the
 [LATEST ON documentation](/docs/reference/sql/latest-on/).
 

--- a/docs/get-started/first-database.md
+++ b/docs/get-started/first-database.md
@@ -66,14 +66,21 @@ about the functions used here, see the
 [row generator](/docs/reference/function/row-generator/) pages.
 
 Our `sensors` table now contains 10,000 randomly-generated sensor values of
-different makes and in various cities. It should look like the table below:
+different makes and in various cities. Use this command to view the table:
+
+
+```questdb-sql
+'sensors';
+```
+
+It should look like the table below:
 
 | ID  | make              | city     |
 | --- | ----------------- | -------- |
-| 1   | RS Pro            | New York |
-| 2   | Honeywell         | Chicago  |
-| 3   | United Automation | Miami    |
-| 4   | Honeywell         | Chicago  |
+| 1   | Honeywell         | Chicago  |
+| 2   | United Automation | Miami    |
+| 3   | Honeywell         | Chicago  | 
+| 4   | Omron             | Miami    | 
 | ... | ...               | ...      |
 
 Let's now create some sensor readings. In this case, we will create the table

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -158,7 +158,7 @@ when starting services:
 - [GROUP BY](/docs/reference/sql/group-by/)
 - [INSERT](/docs/reference/sql/insert/)
 - [JOIN](/docs/reference/sql/join/)
-- [LATEST BY](/docs/reference/sql/latest-on/)
+- [LATEST ON](/docs/reference/sql/latest-on/)
 - [LIMIT](/docs/reference/sql/limit/)
 - [ORDER BY](/docs/reference/sql/order-by/)
 - [RENAME TABLE](/docs/reference/sql/rename/)

--- a/docs/reference/command-line-options.md
+++ b/docs/reference/command-line-options.md
@@ -67,7 +67,7 @@ questdb.exe [start|stop|status|install|remove] \
 | Option | Description                                                                                                                                                                                                          |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-d`   | Expects a `dir` directory value which is a folder that will be used as QuestDB's root directory. For more information and the default values, see the [default root](#default-root-directory) section below.         |
-| `-t`   | Expects a `tag` string value which will be as a tag for the service. This option allows users to run several QuestDB services and manage them separately. If this option omitted, the default tag will be `questdb`. |
+| `-t`   | Expects a `tag` string value which will be as a tag for the service. This option allows users to run several QuestDB services and manage them separately. If this option is omitted, the default tag will be `questdb`. |
 | `-f`   | Force re-deploying the Web Console. Without this option, the Web Console is cached and deployed only when missing.                                                                                                   |
 | `-j`   | **Windows only!** This option allows to specify a path to `JAVA_HOME`.                                                                                                                                               |
 

--- a/docs/reference/sql/sample-by.md
+++ b/docs/reference/sql/sample-by.md
@@ -56,13 +56,14 @@ SELECT ts, count() FROM trades SAMPLE BY 1h
 
 ## Fill options
 
-The `FILL` keyword is optional and expects a single `fillOption` strategy which
-will be applied to a single aggregate column. The following restrictions apply:
+The `FILL` keyword is optional and expects one or more `fillOption` strategies
+which will be applied to one or more aggregate columns. The following
+restrictions apply:
 
 - Keywords denoting fill strategies may not be combined. Only one option from
   `NONE`, `NULL`, `PREV`, `LINEAR` and constants may be used.
-- `FILL()` does not support a list and therefore can only be applied to a single
-  aggregate column.
+- `LINEAR` strategy is not supported for keyed queries, i.e. queries that
+  contain non-aggregated columns other than the timestamp in the SELECT clause.
 
 | fillOption | Description                                                                                                               |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -167,6 +168,22 @@ ALIGN TO ...
 ```
 
 :::
+
+### Multiple fill values
+
+`FILL()` accepts a list of values where each value corresponds to a single
+aggregate column in the SELECT clause order:
+
+```questdb-sql
+SELECT min(price), max(price), avg(price), ts
+FROM prices
+SAMPLE BY 1h
+FILL(NULL, 10, PREV);
+```
+
+In the above query `min(price)` aggregate will get `FILL(NULL)` strategy
+applied, `max(price)` will get `FILL(10)`, and `avg(price)` will get
+`FILL(PREV)`.
 
 ## Sample calculation
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -79,7 +79,7 @@ const FeatureTabs = () => {
               size="small"
               variant={opened === "digital" ? "primary" : "tertiary"}
             >
-              Digital transformation
+              Simplicity
             </Button>
             <Button
               className={meCss.menu__button}
@@ -87,7 +87,7 @@ const FeatureTabs = () => {
               size="small"
               variant={opened === "realtime" ? "primary" : "tertiary"}
             >
-              Real-time insights
+              Performance
             </Button>
             <Button
               className={meCss.menu__button}
@@ -95,7 +95,7 @@ const FeatureTabs = () => {
               size="small"
               variant={opened === "integration" ? "primary" : "tertiary"}
             >
-              Enterprise integration
+              Open Source
             </Button>
           </div>
 
@@ -105,11 +105,11 @@ const FeatureTabs = () => {
                 [meCss["menu__panel--active"]]: opened === "digital",
               })}
             >
-              <p className={prCss.property}>Reduce hardware costs</p>
-              <p className={prCss.property}>Contain operational complexity</p>
-              <p className={prCss.property}>Decrease development costs</p>
-              <p className={prCss.property}>Cloud native (AWS, Azure, GCP)</p>
-              <p className={prCss.property}>On-premises or embedded</p>
+              <p className={prCss.property}>Query with SQL</p>
+              <p className={prCss.property}>Deploy via Docker or binaries</p>
+              <p className={prCss.property}>Interactive web console</p>
+              <p className={prCss.property}>Postgres and InfluxDB line protocols</p>
+              <p className={prCss.property}>Cloud-native or on-premises</p>
             </div>
 
             <div
@@ -117,10 +117,11 @@ const FeatureTabs = () => {
                 [meCss["menu__panel--active"]]: opened === "realtime",
               })}
             >
-              <p className={prCss.property}>Streaming</p>
-              <p className={prCss.property}>Operational analytics / OLAP</p>
-              <p className={prCss.property}>Monitoring and observability</p>
-              <p className={prCss.property}>Predictive analytics</p>
+              <p className={prCss.property}>High-throughput ingestion</p>
+              <p className={prCss.property}>Optimized SQL queries</p>
+              <p className={prCss.property}>Real-time streaming</p>
+              <p className={prCss.property}>Lower infrastructure costs</p>
+              <p className={prCss.property}>Less operational complexity</p>
             </div>
 
             <div
@@ -128,16 +129,15 @@ const FeatureTabs = () => {
                 [meCss["menu__panel--active"]]: opened === "integration",
               })}
             >
-              <p className={prCss.property}>Active directory</p>
-              <p className={prCss.property}>High-performance replication</p>
-              <p className={prCss.property}>High-availability</p>
-              <p className={prCss.property}>Clustering</p>
-              <p className={prCss.property}>Enterprise security</p>
-              <p className={prCss.property}>Postgres compatible</p>
+              <p className={prCss.property}>Apache License 2.0</p>
+              <p className={prCss.property}>Thriving developer community</p>
+              <p className={prCss.property}>Transparent development</p>
+              <p className={prCss.property}>Popular open source integrations</p>
+              <p className={prCss.property}>Embedded in Java applications</p>
             </div>
 
-            <Button className={meCss.menu__cta} to="/enterprise">
-              Enterprise &gt;
+            <Button className={meCss.menu__cta} to="https://github.com/questdb/questdb#try-questdb">
+              Get Started &gt;
             </Button>
           </div>
         </div>


### PR DESCRIPTION
In the 'QuestDB 6.2 January release, SQL JIT compiler' release blog , 'New LATEST BY syntax and improvements' section (https://questdb.io/blog/2022/01/27/release-sql-jit-compiler/#new-latest-by-syntax-and-improvements), I updated the following. 

- Updated the 'LATEST BY documentation' link to 'LATEST ON' since the link directs users to the 'LATEST ON' page (https://questdb.io/docs/reference/sql/latest-on/). 
- Updated the section so that new users don't get confused between the deprecated LATEST BY syntax and the newer LATEST ON syntax.

If my understanding is correct and you agree with it, please feel free to accept the updates.